### PR TITLE
Fixing issue with serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IntelliJ IDEA editor files
+.idea
+*.iml

--- a/rcsb/utils/io/IoUtil.py
+++ b/rcsb/utils/io/IoUtil.py
@@ -74,6 +74,11 @@ class IoUtil(object):
             bool: status of serialization operation; true for success or false otherwise
 
         """
+
+        directory = os.path.dirname(filePath)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
         ret = False
         fmt = str(format).lower()
         if fmt in ['mmcif']:


### PR DESCRIPTION
I run into an issue trying to run tests. The code assumes the 'test-output' directory exists while its doesn't during the first run.

My naive approach will be to ensure that parent directory exists at serialization call. Perhaps, there is a better place to keep this logic. @jdwestbrook, please, advise.